### PR TITLE
Test errors in API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ fortran bindings to duckdb c api
   - [x] Test blob columns
   - [x] Test boolean columns
   - [x] Test decimal columns 
-  - [ ] Test errors in C API
+  - [x] Test errors in C API
   - [ ] Test C API config
   - [ ] Issue #2058: Cleanup after execution of invalid SQL statement causes segmentation fault
   - [ ] Decimal -> Double casting issue

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ fortran bindings to duckdb c api
   - [ ] Test Table Function named parameters in C API
 - [ ] **test_capi_appender.cpp**
   - [ ] Test appending into DECIMAL in C API
-  - [ ] Test appender statements in C API
-  - [ ] Test append timestamp in C API
+  - [x] Test appender statements in C API
+  - [x] Test append timestamp in C API
 - [ ] **test_capi_arrow.cpp**
   - [ ] Test arrow in C API
 - [ ] **test_capi_complex_types.cpp**

--- a/src/duckdb.f90
+++ b/src/duckdb.f90
@@ -11,7 +11,7 @@ module duckdb
   ! public :: duckdb_extracted_statements
   ! public :: duckdb_pending_result
   public :: duckdb_appender
-  ! public :: duckdb_arrow
+  public :: duckdb_arrow
   ! public :: duckdb_arrow_schema
   ! public :: duckdb_config
   ! public :: duckdb_arrow_array
@@ -161,7 +161,7 @@ module duckdb
   ! public :: duckdb_bind_string ! helper function to wrap duckdb_bind_varchar_length
   ! public :: duckdb_bind_blob ! the way it should work
   public :: duckdb_bind_null
-  ! public :: duckdb_execute_prepared
+  public :: duckdb_execute_prepared
   ! public :: duckdb_execute_prepared_arrow
 
   public :: duckdb_data_chunk_get_size
@@ -231,6 +231,10 @@ module duckdb
   public :: duckdb_append_blob
   public :: duckdb_append_null
   public :: duckdb_append_data_chunk
+
+  public :: duckdb_query_arrow 
+  public :: duckdb_query_arrow_error
+  public :: duckdb_destroy_arrow
 
   public :: STANDARD_VECTOR_SIZE
 
@@ -1080,6 +1084,12 @@ module duckdb
     end function duckdb_bind_null_
 
     ! DUCKDB_API duckdb_state duckdb_execute_prepared(duckdb_prepared_statement prepared_statement, duckdb_result *out_result);
+    function duckdb_execute_prepared(prepared_statement, out_result) bind(c, name='duckdb_execute_prepared') result(res)
+      import :: duckdb_state, duckdb_prepared_statement, duckdb_result
+      integer(kind(duckdb_state)) :: res
+      type(duckdb_prepared_statement), value :: prepared_statement
+      type(duckdb_result) :: out_result
+    end function duckdb_execute_prepared
 
     ! DUCKDB_API duckdb_state duckdb_execute_prepared_arrow(duckdb_prepared_statement prepared_statement, duckdb_arrow *out_result);
 
@@ -1767,6 +1777,13 @@ module duckdb
     ! =========================================================================
 
     ! DUCKDB_API duckdb_state duckdb_query_arrow(duckdb_connection connection, const char *query, duckdb_arrow *out_result);
+    function duckdb_query_arrow_(connection, query, out_result) bind(c, name='duckdb_query_arrow') result(res)
+      import :: duckdb_state, duckdb_connection, duckdb_arrow, c_char
+      integer(kind(duckdb_state)) :: res
+      type(duckdb_connection), value :: connection
+      character(kind=c_char) :: query
+      type(duckdb_arrow) :: out_result
+    end function duckdb_query_arrow_
 
     ! DUCKDB_API duckdb_state duckdb_query_arrow_schema(duckdb_arrow result, duckdb_arrow_schema *out_schema);
 
@@ -1779,8 +1796,17 @@ module duckdb
     ! DUCKDB_API idx_t duckdb_arrow_rows_changed(duckdb_arrow result);
 
     ! DUCKDB_API const char *duckdb_query_arrow_error(duckdb_arrow result);
+    function duckdb_query_arrow_error_(result) bind(c, name='duckdb_query_arrow_error') result(err)
+      import :: c_ptr, duckdb_arrow
+      type(c_ptr) :: err
+      type(duckdb_arrow), value :: result
+    end function duckdb_query_arrow_error_
 
     ! DUCKDB_API void duckdb_destroy_arrow(duckdb_arrow *result);
+    subroutine duckdb_destroy_arrow(result) bind(c, name='duckdb_destroy_arrow')
+      import :: duckdb_arrow
+      type(duckdb_arrow) :: result
+    end subroutine duckdb_destroy_arrow
 
     ! =========================================================================
     ! Threading Information
@@ -2641,7 +2667,24 @@ module duckdb
     ! =========================================================================
     ! Arrow Interface
     ! =========================================================================
+    function duckdb_query_arrow(connection, query, out_result) result(res)
+      integer(kind(duckdb_state)) :: res
+      type(duckdb_connection), value :: connection
+      character(len=*) :: query
+      type(duckdb_arrow) :: out_result
+      res = duckdb_query_arrow_(connection, query//c_null_char, out_result)
+    end function duckdb_query_arrow
 
+    function duckdb_query_arrow_error(res) result(err)
+      character(len=:), allocatable :: err
+      type(c_ptr) :: tmp
+      type(duckdb_arrow) :: res
+      err = "NULL"
+      if (c_associated(res%arrw)) then
+        tmp = duckdb_query_arrow_error_(res)
+        if (c_associated(tmp)) call c_f_str_ptr(tmp, err)
+      end if
+    end function duckdb_query_arrow_error
     ! =========================================================================
     ! Threading Information
     ! =========================================================================

--- a/src/duckdb.f90
+++ b/src/duckdb.f90
@@ -7,7 +7,7 @@ module duckdb
   public :: duckdb_database
   public :: duckdb_connection
 
-  ! public ::  duckdb_prepared_statement
+  public ::  duckdb_prepared_statement
   ! public :: duckdb_extracted_statements
   ! public :: duckdb_pending_result
   public :: duckdb_appender
@@ -431,12 +431,12 @@ module duckdb
     ! =========================================================================
 
     ! DUCKDB_API duckdb_state duckdb_open(const char *path, duckdb_database *out_database);
-    function duckdb_open(path, out_database) bind(c, name='duckdb_open') result(res)
-      import :: duckdb_state, c_ptr, duckdb_database
+    function duckdb_open_(path, out_database) bind(c, name='duckdb_open') result(res)
+      import :: duckdb_state, c_char, duckdb_database
       integer(kind(duckdb_state)) :: res
-      type(c_ptr), value :: path
+      character(kind=c_char), value :: path
       type(duckdb_database) :: out_database
-    end function duckdb_open
+    end function duckdb_open_
 
     ! DUCKDB_API duckdb_state duckdb_open_ext(const char *path, duckdb_database *out_database, duckdb_config config,char **out_error);
     ! TODO
@@ -1811,7 +1811,13 @@ module duckdb
     ! =========================================================================
     ! Open/Connect
     ! =========================================================================
-
+    function duckdb_open(path, out_database) result(res)
+      integer(kind(duckdb_state)) :: res
+      character(len=*) :: path 
+      type(duckdb_database) :: out_database
+      res = duckdb_open_(path//c_null_char, out_database)
+    end function duckdb_open
+    
     function duckdb_library_version() result(res)
       character(len=:), allocatable :: res
       type(c_ptr) :: tmp

--- a/test/test_appender.f90
+++ b/test/test_appender.f90
@@ -41,7 +41,7 @@ contains
     type(duckdb_blob) :: blob_data
 
     ! Open db in in-memory mode
-    call check(error, duckdb_open(c_null_ptr, db) == duckdbsuccess, "Could not open db.")
+    call check(error, duckdb_open("", db) == duckdbsuccess, "Could not open db.")
     if (allocated(error)) return
     call check(error, duckdb_connect(db, con) == duckdbsuccess, "Could not start connection.")
     if (allocated(error)) return
@@ -603,7 +603,7 @@ contains
     integer(kind=kind(duckdb_state)) :: status
 
     ! Open db in in-memory mode
-    call check(error, duckdb_open(c_null_ptr, db) == duckdbsuccess, "Could not open db.")
+    call check(error, duckdb_open("", db) == duckdbsuccess, "Could not open db.")
     if (allocated(error)) return
     call check(error, duckdb_connect(db, con) == duckdbsuccess, "Could not start connection.")
     if (allocated(error)) return

--- a/test/test_data_chunk.f90
+++ b/test/test_data_chunk.f90
@@ -44,7 +44,7 @@ subroutine test_chunks(error)
   logical :: is_valid
 
   ! Open db in in-memory mode
-  call check(error, duckdb_open(c_null_ptr, db) == duckdbsuccess)
+  call check(error, duckdb_open("", db) == duckdbsuccess)
   if (allocated(error)) return
 
   call check(error, duckdb_connect(db, con) == duckdbsuccess)
@@ -183,7 +183,7 @@ subroutine test_data_chunk_api(error)
   integer(kind=int64) :: col1_validity, col2_validity
 
   ! Open db in in-memory mode
-  call check(error, duckdb_open(c_null_ptr, db) == duckdbsuccess)
+  call check(error, duckdb_open("", db) == duckdbsuccess)
   if (allocated(error)) return
 
   call check(error, duckdb_connect(db, con) == duckdbsuccess)

--- a/test/test_fortran_api.f90
+++ b/test/test_fortran_api.f90
@@ -47,7 +47,7 @@ module test_fortran_api
       type(c_ptr) :: data_in
 
       ! Open data in in-memory mode
-      call check(error, duckdb_open(c_null_ptr, db) == duckdbsuccess, "open database")
+      call check(error, duckdb_open("", db) == duckdbsuccess, "open database")
       if (allocated(error)) return
 
       call check(error, duckdb_connect(db, conn) == duckdbsuccess, "connect database")
@@ -112,7 +112,7 @@ module test_fortran_api
       type(duckdb_result) :: ddb_result = duckdb_result()
 
       ! Open data in in-memory mode
-      call check(error, duckdb_open(c_null_ptr, db) == duckdbsuccess)
+      call check(error, duckdb_open("", db) == duckdbsuccess)
       if (allocated(error)) return
 
       call check(error, duckdb_connect(db, conn) == duckdbsuccess)
@@ -150,7 +150,7 @@ module test_fortran_api
       character(len=:), pointer :: str
 
       ! Open data in in-memory mode
-      call check(error, duckdb_open(c_null_ptr, db) == duckdbsuccess)
+      call check(error, duckdb_open("", db) == duckdbsuccess)
       if (allocated(error)) return
 
       call check(error, duckdb_connect(db, conn) == duckdbsuccess)
@@ -194,7 +194,7 @@ module test_fortran_api
       type(duckdb_result) :: ddb_result = duckdb_result()
 
       ! Open data in in-memory mode
-      call check(error, duckdb_open(c_null_ptr, db) == duckdbsuccess)
+      call check(error, duckdb_open("", db) == duckdbsuccess)
       if (allocated(error)) return
 
       call check(error, duckdb_connect(db, conn) == duckdbsuccess)
@@ -272,7 +272,7 @@ module test_fortran_api
       type(duckdb_result) :: ddb_result = duckdb_result()
 
       ! Open data in in-memory mode
-      call check(error, duckdb_open(c_null_ptr, db) == duckdbsuccess)
+      call check(error, duckdb_open("", db) == duckdbsuccess)
       if (allocated(error)) return
 
       call check(error, duckdb_connect(db, conn) == duckdbsuccess)
@@ -393,7 +393,7 @@ module test_fortran_api
       integer :: i
 
       ! Open data in in-memory mode
-      call check(error, duckdb_open(c_null_ptr, db) == duckdbsuccess, "open database")
+      call check(error, duckdb_open("", db) == duckdbsuccess, "open database")
       if (allocated(error)) return
 
       call check(error, duckdb_connect(db, conn) == duckdbsuccess, "connect database")
@@ -505,7 +505,7 @@ module test_fortran_api
       integer :: i
 
       ! Open data in in-memory mode
-      call check(error, duckdb_open(c_null_ptr, db) == duckdbsuccess, "open database")
+      call check(error, duckdb_open("", db) == duckdbsuccess, "open database")
       if (allocated(error)) return
 
       call check(error, duckdb_connect(db, conn) == duckdbsuccess, "connect database")
@@ -603,7 +603,7 @@ module test_fortran_api
       type(duckdb_date_struct) :: date
 
       ! Open data in in-memory mode
-      call check(error, duckdb_open(c_null_ptr, db) == duckdbsuccess, "open database")
+      call check(error, duckdb_open("", db) == duckdbsuccess, "open database")
       if (allocated(error)) return
 
       call check(error, duckdb_connect(db, conn) == duckdbsuccess, "connect database")
@@ -670,7 +670,7 @@ module test_fortran_api
       type(duckdb_time_struct) :: time_val
 
       ! Open data in in-memory mode
-      call check(error, duckdb_open(c_null_ptr, db) == duckdbsuccess, "open database")
+      call check(error, duckdb_open("", db) == duckdbsuccess, "open database")
       if (allocated(error)) return
 
       call check(error, duckdb_connect(db, conn) == duckdbsuccess, "connect database")
@@ -734,7 +734,7 @@ module test_fortran_api
       type(duckdb_result) :: result = duckdb_result()
 
       ! Open data in in-memory mode
-      call check(error, duckdb_open(c_null_ptr, db) == duckdbsuccess, "open database")
+      call check(error, duckdb_open("", db) == duckdbsuccess, "open database")
       if (allocated(error)) return
 
       call check(error, duckdb_connect(db, conn) == duckdbsuccess, "connect database")
@@ -803,7 +803,7 @@ module test_fortran_api
       type(duckdb_time_struct) :: time_val
 
       ! Open data in in-memory mode
-      call check(error, duckdb_open(c_null_ptr, db) == duckdbsuccess, "open database")
+      call check(error, duckdb_open("", db) == duckdbsuccess, "open database")
       if (allocated(error)) return
 
       call check(error, duckdb_connect(db, conn) == duckdbsuccess, "connect database")
@@ -853,7 +853,7 @@ module test_fortran_api
       type(duckdb_result) :: result = duckdb_result()
 
       ! Open data in in-memory mode
-      call check(error, duckdb_open(c_null_ptr, db) == duckdbsuccess)
+      call check(error, duckdb_open("", db) == duckdbsuccess)
       if (allocated(error)) return
 
       call check(error, duckdb_connect(db, conn) == duckdbsuccess)
@@ -1123,6 +1123,43 @@ module test_fortran_api
 
     end subroutine test_decimal_columns   
     
+    subroutine test_errors(error)
+
+      type(error_type), allocatable, intent(out) :: error
+      type(duckdb_database) :: db
+      type(duckdb_connection) :: conn, con_null
+      type(duckdb_result) :: result = duckdb_result()
+      type(duckdb_prepared_statement) :: stmt
+
+      ! cannot open database in random directory
+      call check(error, duckdb_open("/this/directory/should/not/exist/hopefully", db), &
+        duckdberror, "can open db in nonexisting path")
+      if (allocated(error)) return
+      call check(error, duckdb_open("", db), &
+        duckdbsuccess, "cannot open in memory db")
+      if (allocated(error)) return
+      call check(error, duckdb_connect(db, conn) == duckdbsuccess, "connect database")
+      if (allocated(error)) return
+
+      call check(error, duckdb_query(conn, "SELEC * FROM TABLE", result), &
+        duckdberror, "syntax error in query")
+      if (allocated(error)) return
+      call check(error, duckdb_query(conn, "SELECT * FROM TABLE", result), &
+        duckdberror, "bind error in query")
+      if (allocated(error)) return
+
+      ! fail prepare API calls
+      call check(error, duckdb_prepare(con_null, "SELECT 42", stmt), &
+        duckdberror, "prepare with null connection")
+      if (allocated(error)) return
+      call check(error, duckdb_prepare(conn, "", stmt), &
+        duckdberror, "prepare with empty query")
+      if (allocated(error)) return
+      call check(error, .not. c_associated(stmt%prep), "uninitialised statement")
+      if (allocated(error)) return
+  
+    end subroutine test_errors
+
     logical function hugeint_equals_hugeint(left, right) result(res)
       type(duckdb_hugeint), intent(in) :: left, right
       res = left%lower == right%lower .and. left%upper == right%upper

--- a/test/test_fortran_api.f90
+++ b/test/test_fortran_api.f90
@@ -1157,7 +1157,19 @@ module test_fortran_api
       if (allocated(error)) return
       call check(error, .not. c_associated(stmt%prep), "uninitialised statement")
       if (allocated(error)) return
-  
+
+      call check(error, duckdb_prepare(conn, "SELECT * from INVALID_TABLE", stmt), &
+        duckdberror, "prepare with invalid query")
+      if (allocated(error)) return
+      call check(error, duckdb_prepare_error(stmt) /= "", "empty prepare error")
+      if (allocated(error)) return
+
+      stmt = duckdb_prepared_statement()
+      call check(error, duckdb_prepare_error(stmt) == "", "non empty prepare error")
+      if (allocated(error)) return    
+        
+      call duckdb_destroy_prepare(stmt)
+
     end subroutine test_errors
 
     logical function hugeint_equals_hugeint(left, right) result(res)

--- a/test/test_parquet_files.f90
+++ b/test/test_parquet_files.f90
@@ -26,7 +26,7 @@ end subroutine collect_parquet_files
     integer :: i, j, nc, nr
 
     ! Open data in in-memory mode
-    call check(error, duckdb_open(c_null_ptr, db) == duckdbsuccess)
+    call check(error, duckdb_open("", db) == duckdbsuccess)
     if (allocated(error)) return
 
     call check(error, duckdb_connect(db, con) == duckdbsuccess)

--- a/test/test_starting_database.f90
+++ b/test/test_starting_database.f90
@@ -18,7 +18,7 @@ contains
     type(error_type), allocatable, intent(out) :: error
     type(duckdb_database) :: database
     type(duckdb_connection) :: connection
-    call check(error, duckdb_open(c_null_ptr, database) == duckdbsuccess)
+    call check(error, duckdb_open("", database) == duckdbsuccess)
     if (allocated(error)) return
     call check(error, duckdb_connect(database, connection) == duckdbsuccess)
     if (allocated(error)) return
@@ -32,7 +32,7 @@ contains
     type(duckdb_connection) :: connection(100)
     integer :: i, j
     do i = 1, 10
-      call check(error, duckdb_open(c_null_ptr, database(i)) == duckdbsuccess)
+      call check(error, duckdb_open("", database(i)) == duckdbsuccess)
       if (allocated(error)) return
       do j = 1, 10
         call check(error, duckdb_connect(database(i), connection((i - 1)*10 + j)) == duckdbsuccess)


### PR DESCRIPTION
Progressing with "Test errors in C API" test case. 
Small refactoring for `duckdb_open` to make sure we can pass a path to a file to open an actual database. Now pass an empty string for in memory mode. 
In the errors test there is now a failing test on duckdb_prepare statements: https://github.com/freevryheid/duckdb/blob/d6435f7861d8f7596a72460b4bcb343b976bb471/test/test_fortran_api.f90#L1160